### PR TITLE
Fixed moonlight crystal storage Block

### DIFF
--- a/src/main/resources/data/arclight/recipes/moonlight_block.json
+++ b/src/main/resources/data/arclight/recipes/moonlight_block.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "arclight:arclight_crystal"
+      "item": "arclight:moonlight_crystal"
     }
   },
   "pattern": [
@@ -11,6 +11,6 @@
     "###"
   ],
   "result": {
-    "item": "arclight:arclight_block"
+    "item": "arclight:moonlight_block"
   }
 }


### PR DESCRIPTION
Changed `arclight_crystal` to `moonlight_crystal` to fix item error

changed result to properly output the right storage block

Resolves #1